### PR TITLE
Update media serializer with tags and read-only fields

### DIFF
--- a/mediafiles/serializers.py
+++ b/mediafiles/serializers.py
@@ -1,7 +1,16 @@
+# serializers.py
 from rest_framework import serializers
 from .models import Media
 
 class MediaSerializer(serializers.ModelSerializer):
+    tags = serializers.ListField(
+        child=serializers.CharField(max_length=50),
+        required=False
+    )
+
     class Meta:
         model = Media
         fields = '__all__'
+        read_only_fields = [
+            'user', 'uploaded_at', 'size', 'file_name', 'file_type', 'file'
+        ]


### PR DESCRIPTION
Add `tags` field and define `read_only_fields` in `MediaSerializer` to allow tagging and protect sensitive media metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab159438-c0da-4b85-82ee-4d8578796ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ab159438-c0da-4b85-82ee-4d8578796ad7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

